### PR TITLE
Task 1: Add tutorial self enrolment columns and indexes to task_defin…

### DIFF
--- a/db/migrate/20250912012227_add_tutorial_self_enrolment_to_task_definitions.rb
+++ b/db/migrate/20250912012227_add_tutorial_self_enrolment_to_task_definitions.rb
@@ -1,0 +1,17 @@
+class AddTutorialSelfEnrolmentToTaskDefinitions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :task_definitions, :tutorial_self_enrolment_enabled, :boolean, default: false, null: false
+    add_reference :task_definitions, :tutorial_self_enrolment_stream, foreign_key: { to_table: :tutorial_streams }, null: true
+
+    # Add index for better query performance
+    add_index :task_definitions, :tutorial_self_enrolment_enabled
+    add_index :task_definitions, :tutorial_self_enrolment_stream_id
+  end
+
+  def down
+    remove_index :task_definitions, :tutorial_self_enrolment_enabled
+    remove_index :task_definitions, :tutorial_self_enrolment_stream_id
+    remove_reference :task_definitions, :tutorial_self_enrolment_stream
+    remove_column :task_definitions, :tutorial_self_enrolment_enabled
+  end
+end

--- a/db/migrate/20250912012227_add_tutorial_self_enrolment_to_task_definitions.rb
+++ b/db/migrate/20250912012227_add_tutorial_self_enrolment_to_task_definitions.rb
@@ -1,17 +1,13 @@
 class AddTutorialSelfEnrolmentToTaskDefinitions < ActiveRecord::Migration[7.1]
   def change
-    add_column :task_definitions, :tutorial_self_enrolment_enabled, :boolean, default: false, null: false
-    add_reference :task_definitions, :tutorial_self_enrolment_stream, foreign_key: { to_table: :tutorial_streams }, null: true
+    unless column_exists?(:task_definitions, :tutorial_self_enrolment_enabled)
+      add_column :task_definitions, :tutorial_self_enrolment_enabled, :boolean, default: false, null: false
+      add_index :task_definitions, :tutorial_self_enrolment_enabled
+    end
 
-    # Add index for better query performance
-    add_index :task_definitions, :tutorial_self_enrolment_enabled
-    add_index :task_definitions, :tutorial_self_enrolment_stream_id
-  end
-
-  def down
-    remove_index :task_definitions, :tutorial_self_enrolment_enabled
-    remove_index :task_definitions, :tutorial_self_enrolment_stream_id
-    remove_reference :task_definitions, :tutorial_self_enrolment_stream
-    remove_column :task_definitions, :tutorial_self_enrolment_enabled
+    unless column_exists?(:task_definitions, :tutorial_self_enrolment_stream_id)
+      add_reference :task_definitions, :tutorial_self_enrolment_stream, foreign_key: { to_table: :tutorial_streams }, null: true
+      add_index :task_definitions, :tutorial_self_enrolment_stream_id
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
-  create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
+  create_table "activity_types", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
     t.datetime "created_at", null: false
@@ -20,21 +20,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["name"], name: "index_activity_types_on_name", unique: true
   end
 
-  create_table "auth_tokens", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "auth_tokens", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "auth_token_expiry", null: false
     t.bigint "user_id"
     t.string "authentication_token", null: false
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end
 
-  create_table "breaks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "breaks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "start_date", null: false
     t.integer "number_of_weeks", null: false
     t.bigint "teaching_period_id"
     t.index ["teaching_period_id"], name: "index_breaks_on_teaching_period_id"
   end
 
-  create_table "campuses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "campuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "mode", null: false
     t.string "abbreviation", null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["name"], name: "index_campuses_on_name", unique: true
   end
 
-  create_table "comments_read_receipts", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "comments_read_receipts", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_comment_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -54,7 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_comments_read_receipts_on_user_id"
   end
 
-  create_table "discussion_comments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "discussion_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "time_started"
     t.datetime "time_completed"
     t.integer "number_of_prompts"
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "group_memberships", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "group_memberships", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "group_id"
     t.bigint "project_id"
     t.boolean "active", default: true
@@ -72,7 +72,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["project_id"], name: "index_group_memberships_on_project_id"
   end
 
-  create_table "group_sets", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "group_sets", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "name"
     t.boolean "allow_students_to_create_groups", default: true
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["unit_id"], name: "index_group_sets_on_unit_id"
   end
 
-  create_table "group_submissions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "group_submissions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "group_id"
     t.string "notes"
     t.bigint "submitted_by_project_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_definition_id"], name: "index_group_submissions_on_task_definition_id"
   end
 
-  create_table "groups", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "groups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "group_set_id"
     t.bigint "tutorial_id"
     t.string "name"
@@ -109,7 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["tutorial_id"], name: "index_groups_on_tutorial_id"
   end
 
-  create_table "learning_outcome_task_links", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_outcome_task_links", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.integer "rating"
     t.bigint "task_definition_id"
@@ -122,7 +122,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_id"], name: "index_learning_outcome_task_links_on_task_id"
   end
 
-  create_table "learning_outcomes", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_outcomes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.integer "ilo_number"
     t.string "name"
@@ -131,7 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["unit_id"], name: "index_learning_outcomes_on_unit_id"
   end
 
-  create_table "logins", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "logins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "timestamp"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -139,7 +139,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_logins_on_user_id"
   end
 
-  create_table "overseer_assessments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "marking_sessions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "marker_id", null: false
+    t.bigint "unit_id", null: false
+    t.string "ip_address"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "duration_minutes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["marker_id", "unit_id", "ip_address", "updated_at"], name: "index_marking_sessions_on_user_unit_ip_and_time"
+    t.index ["marker_id"], name: "index_marking_sessions_on_marker_id"
+    t.index ["unit_id"], name: "index_marking_sessions_on_unit_id"
+  end
+
+  create_table "overseer_assessments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.string "submission_timestamp", null: false
     t.string "result_task_status"
@@ -150,7 +164,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_id"], name: "index_overseer_assessments_on_task_id"
   end
 
-  create_table "overseer_images", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "overseer_images", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "tag", null: false
     t.datetime "created_at", null: false
@@ -160,7 +174,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.datetime "last_pulled_date"
   end
 
-  create_table "projects", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "projects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "project_role"
     t.datetime "created_at", null: false
@@ -187,14 +201,29 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
-  create_table "roles", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "roles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "task_comments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "session_activities", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "marking_session_id", null: false
+    t.string "action"
+    t.bigint "project_id"
+    t.bigint "task_id"
+    t.bigint "task_definition_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["action", "task_id", "created_at"], name: "index_session_activities_on_action_task_created_at"
+    t.index ["marking_session_id"], name: "index_session_activities_on_marking_session_id"
+    t.index ["project_id"], name: "index_session_activities_on_project_id"
+    t.index ["task_definition_id"], name: "index_session_activities_on_task_definition_id"
+    t.index ["task_id"], name: "index_session_activities_on_task_id"
+  end
+
+  create_table "task_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
     t.string "comment", limit: 4096
@@ -225,7 +254,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_task_comments_on_user_id"
   end
 
-  create_table "task_definitions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_definitions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "name"
     t.string "description", limit: 4096
@@ -250,13 +279,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.bigint "overseer_image_id"
     t.string "tii_group_id"
     t.string "moss_language"
+    t.boolean "tutorial_self_enrolment_enabled", default: false, null: false
+    t.bigint "tutorial_self_enrolment_stream_id"
     t.index ["group_set_id"], name: "index_task_definitions_on_group_set_id"
     t.index ["overseer_image_id"], name: "index_task_definitions_on_overseer_image_id"
+    t.index ["tutorial_self_enrolment_enabled"], name: "index_task_definitions_on_tutorial_self_enrolment_enabled"
+    t.index ["tutorial_self_enrolment_stream_id"], name: "index_task_definitions_on_tutorial_self_enrolment_stream_id"
     t.index ["tutorial_stream_id"], name: "index_task_definitions_on_tutorial_stream_id"
     t.index ["unit_id"], name: "index_task_definitions_on_unit_id"
   end
 
-  create_table "task_engagements", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_engagements", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "engagement_time"
     t.string "engagement"
     t.bigint "task_id"
@@ -265,7 +298,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_id"], name: "index_task_engagements_on_task_id"
   end
 
-  create_table "task_pins", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_pins", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -275,7 +308,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "fk_rails_915df186ed"
   end
 
-  create_table "task_similarities", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_similarities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_id"
     t.bigint "other_task_id"
     t.integer "pct"
@@ -290,14 +323,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["tii_submission_id"], name: "index_task_similarities_on_tii_submission_id"
   end
 
-  create_table "task_statuses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_statuses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "task_submissions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "task_submissions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "submission_time"
     t.datetime "assessment_time"
     t.string "outcome"
@@ -309,7 +342,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_id"], name: "index_task_submissions_on_task_id"
   end
 
-  create_table "tasks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "tasks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_definition_id"
     t.bigint "project_id"
     t.bigint "task_status_id"
@@ -335,7 +368,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["task_status_id"], name: "index_tasks_on_task_status_id"
   end
 
-  create_table "teaching_periods", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "teaching_periods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "period", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date", null: false
@@ -394,7 +427,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["tii_task_similarity_id"], name: "index_tii_submissions_on_tii_task_similarity_id"
   end
 
-  create_table "tutorial_enrolments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "tutorial_enrolments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "project_id", null: false
@@ -404,7 +437,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["tutorial_id"], name: "index_tutorial_enrolments_on_tutorial_id"
   end
 
-  create_table "tutorial_streams", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "tutorial_streams", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
     t.datetime "created_at", null: false
@@ -418,7 +451,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["unit_id"], name: "index_tutorial_streams_on_unit_id"
   end
 
-  create_table "tutorials", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "tutorials", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "unit_id"
     t.string "meeting_day"
     t.string "meeting_time"
@@ -437,7 +470,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["unit_role_id"], name: "index_tutorials_on_unit_role_id"
   end
 
-  create_table "unit_roles", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_roles", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "tutorial_id"
     t.datetime "created_at", null: false
@@ -450,7 +483,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_unit_roles_on_user_id"
   end
 
-  create_table "units", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "units", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "description", limit: 4096
     t.datetime "start_date"
@@ -480,7 +513,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["teaching_period_id"], name: "index_units_on_teaching_period_id"
   end
 
-  create_table "users", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -513,7 +546,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["role_id"], name: "index_users_on_role_id"
   end
 
-  create_table "webcal_unit_exclusions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "webcal_unit_exclusions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "webcal_id", null: false
     t.bigint "unit_id", null: false
     t.index ["unit_id", "webcal_id"], name: "index_webcal_unit_exclusions_on_unit_id_and_webcal_id", unique: true
@@ -521,7 +554,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["webcal_id"], name: "fk_rails_d5fab02cb7"
   end
 
-  create_table "webcals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "webcals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "guid", limit: 36, null: false
     t.boolean "include_start_dates", default: false, null: false
     t.bigint "user_id"
@@ -531,4 +564,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_webcals_on_user_id", unique: true
   end
 
+  add_foreign_key "marking_sessions", "units"
+  add_foreign_key "marking_sessions", "users", column: "marker_id"
+  add_foreign_key "session_activities", "marking_sessions"
+  add_foreign_key "session_activities", "projects"
+  add_foreign_key "session_activities", "task_definitions"
+  add_foreign_key "session_activities", "tasks"
+  add_foreign_key "task_definitions", "tutorial_streams", column: "tutorial_self_enrolment_stream_id"
 end


### PR DESCRIPTION
…itions

# Description
introducing the foundational schema changes required to support tutorial self-enrolment as part of the OnTrack feature development. Specifically, it adds two new fields to the task_definitions table:

- tutorial_self_enrolment_enabled (boolean, defaults to false): Indicates if self-enrolment is allowed for the task.
- tutorial_self_enrolment_stream_id (foreign key to tutorial_streams): Points to the tutorial stream eligible for self-enrolment.

Relevant indices are also introduced for query performance.
No new dependencies are required for this change.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual testing

- Ran rails db:migrate successfully on local development environment.
<img width="760" height="144" alt="Screenshot 2025-09-12 at 11 46 50 AM" src="https://github.com/user-attachments/assets/0480c341-7241-43e8-b6fd-250bee463b55" />
- Verified new columns and indices present in db/schema.rb.
<img width="930" height="377" alt="Screenshot 2025-09-12 at 11 47 43 AM" src="https://github.com/user-attachments/assets/c5cc0c6d-2fa9-4d97-8028-16208b657073" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
