### PR TITLE
Student self enrolment active model update

### DIFF
--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -13,6 +13,7 @@ class TaskDefinition < ApplicationRecord
   belongs_to :group_set, optional: true
   belongs_to :tutorial_stream, optional: true
   belongs_to :overseer_image, optional: true
+  belongs_to :tutorial_self_enrolment_stream, class_name: "TutorialStream", optional: true
 
   has_many :tasks, dependent:  :destroy # Destroying a task definition will also nuke any instances
   has_many :group_submissions, dependent: :destroy # Destroying a task definition will also nuke any group submissions
@@ -41,6 +42,8 @@ class TaskDefinition < ApplicationRecord
 
   validates :weighting, presence: true
 
+  validate :self_enrolment_stream_unit_must_match
+
   include TaskDefinitionTiiModule
   include TaskDefinitionSimilarityModule
 
@@ -53,6 +56,16 @@ class TaskDefinition < ApplicationRecord
   def tutorial_stream_present?
     if tutorial_stream.nil? and unit.tutorial_streams.exists?
       errors.add(:tutorial_stream, "must be one of the tutorial streams in the unit")
+    end
+  end
+
+  def tutorial_self_enrolment_enabled?
+    tutorial_self_enrolment_enabled
+  end
+
+  def self_enrolment_stream_unit_must_match
+    if tutorial_self_enrolment_enabled? && tutorial_self_enrolment_stream.present? && tutorial_self_enrolment_stream.unit != unit
+      errors.add(:tutorial_self_enrolment_stream, "must belong to the same unit")
     end
   end
 

--- a/app/models/tutorial_stream.rb
+++ b/app/models/tutorial_stream.rb
@@ -9,6 +9,8 @@ class TutorialStream < ApplicationRecord
   has_many :tutorials, dependent: :destroy
   has_many :task_definitions, -> { order 'start_date ASC, abbreviation ASC' }
 
+  has_many :self_enrolment_task_definitions, class_name: "TaskDefinition", foreign_key: :tutorial_self_enrolment_stream_id, dependent: :nullify
+
   validates :unit, presence: true
   validates :activity_type, presence: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.datetime "auth_token_expiry", null: false
     t.bigint "user_id"
     t.string "authentication_token", null: false
+    t.integer "token_type", default: 0, null: false
+    t.index ["token_type"], name: "index_auth_tokens_on_token_type"
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end
 
@@ -54,6 +56,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.index ["user_id"], name: "index_comments_read_receipts_on_user_id"
   end
 
+  create_table "d2l_assessment_mappings", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "unit_id", null: false
+    t.string "org_unit_id"
+    t.integer "grade_object_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["unit_id"], name: "index_d2l_assessment_mappings_on_unit_id", unique: true
+  end
+
   create_table "discussion_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "time_started"
     t.datetime "time_completed"
@@ -82,6 +93,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.datetime "updated_at"
     t.integer "capacity"
     t.boolean "locked", default: false, null: false
+    t.index ["name", "unit_id"], name: "index_group_sets_on_name_and_unit_id", unique: true
     t.index ["unit_id"], name: "index_group_sets_on_unit_id"
   end
 
@@ -106,6 +118,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.integer "capacity_adjustment", default: 0, null: false
     t.boolean "locked", default: false, null: false
     t.index ["group_set_id"], name: "index_groups_on_group_set_id"
+    t.index ["name", "group_set_id"], name: "index_groups_on_name_and_group_set_id", unique: true
     t.index ["tutorial_id"], name: "index_groups_on_tutorial_id"
   end
 
@@ -128,6 +141,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.string "name"
     t.string "description", limit: 4096
     t.string "abbreviation"
+    t.index ["abbreviation", "unit_id"], name: "index_learning_outcomes_on_abbreviation_and_unit_id", unique: true
     t.index ["unit_id"], name: "index_learning_outcomes_on_unit_id"
   end
 
@@ -137,20 +151,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_logins_on_user_id"
-  end
-
-  create_table "marking_sessions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.bigint "marker_id", null: false
-    t.bigint "unit_id", null: false
-    t.string "ip_address"
-    t.datetime "start_time"
-    t.datetime "end_time"
-    t.integer "duration_minutes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["marker_id", "unit_id", "ip_address", "updated_at"], name: "index_marking_sessions_on_user_unit_ip_and_time"
-    t.index ["marker_id"], name: "index_marking_sessions_on_marker_id"
-    t.index ["unit_id"], name: "index_marking_sessions_on_unit_id"
   end
 
   create_table "overseer_assessments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -172,6 +172,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.text "pulled_image_text"
     t.integer "pulled_image_status"
     t.datetime "last_pulled_date"
+    t.index ["name"], name: "index_overseer_images_on_name", unique: true
+    t.index ["tag"], name: "index_overseer_images_on_tag", unique: true
   end
 
   create_table "projects", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -208,21 +210,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "session_activities", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.bigint "marking_session_id", null: false
-    t.string "action"
-    t.bigint "project_id"
-    t.bigint "task_id"
-    t.bigint "task_definition_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["action", "task_id", "created_at"], name: "index_session_activities_on_action_task_created_at"
-    t.index ["marking_session_id"], name: "index_session_activities_on_marking_session_id"
-    t.index ["project_id"], name: "index_session_activities_on_project_id"
-    t.index ["task_definition_id"], name: "index_session_activities_on_task_definition_id"
-    t.index ["task_id"], name: "index_session_activities_on_task_id"
-  end
-
   create_table "task_comments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "task_id", null: false
     t.bigint "user_id", null: false
@@ -243,10 +230,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.integer "extension_weeks"
     t.string "extension_response"
     t.bigint "reply_to_id"
-    t.bigint "overseer_assessment_id"
+    t.bigint "commentable_id"
+    t.string "commentable_type"
     t.index ["assessor_id"], name: "index_task_comments_on_assessor_id"
+    t.index ["commentable_type", "commentable_id"], name: "index_task_comments_on_commentable_type_and_commentable_id"
     t.index ["discussion_comment_id"], name: "index_task_comments_on_discussion_comment_id"
-    t.index ["overseer_assessment_id"], name: "index_task_comments_on_overseer_assessment_id"
     t.index ["recipient_id"], name: "fk_rails_1dbb49165b"
     t.index ["reply_to_id"], name: "index_task_comments_on_reply_to_id"
     t.index ["task_id"], name: "index_task_comments_on_task_id"
@@ -279,9 +267,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.bigint "overseer_image_id"
     t.string "tii_group_id"
     t.string "moss_language"
+    t.boolean "scorm_enabled", default: false
+    t.boolean "scorm_allow_review", default: false
+    t.boolean "scorm_bypass_test", default: false
+    t.boolean "scorm_time_delay_enabled", default: false
+    t.integer "scorm_attempt_limit", default: 0
     t.boolean "tutorial_self_enrolment_enabled", default: false, null: false
     t.bigint "tutorial_self_enrolment_stream_id"
+    t.index ["abbreviation", "unit_id"], name: "index_task_definitions_on_abbreviation_and_unit_id", unique: true
     t.index ["group_set_id"], name: "index_task_definitions_on_group_set_id"
+    t.index ["name", "unit_id"], name: "index_task_definitions_on_name_and_unit_id", unique: true
     t.index ["overseer_image_id"], name: "index_task_definitions_on_overseer_image_id"
     t.index ["tutorial_self_enrolment_enabled"], name: "index_task_definitions_on_tutorial_self_enrolment_enabled"
     t.index ["tutorial_self_enrolment_stream_id"], name: "index_task_definitions_on_tutorial_self_enrolment_stream_id"
@@ -361,6 +356,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.integer "contribution_pts", default: 3
     t.integer "quality_pts", default: -1
     t.integer "extensions", default: 0, null: false
+    t.integer "scorm_extensions", default: 0, null: false
     t.index ["group_submission_id"], name: "index_tasks_on_group_submission_id"
     t.index ["project_id", "task_definition_id"], name: "tasks_uniq_proj_task_def", unique: true
     t.index ["project_id"], name: "index_tasks_on_project_id"
@@ -375,6 +371,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.integer "year", null: false
     t.datetime "active_until", null: false
     t.index ["period", "year"], name: "index_teaching_periods_on_period_and_year", unique: true
+  end
+
+  create_table "test_attempts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "task_id"
+    t.datetime "attempted_time", null: false
+    t.boolean "terminated", default: false
+    t.boolean "completion_status", default: false
+    t.boolean "success_status", default: false
+    t.float "score_scaled", default: 0.0
+    t.text "cmi_datamodel"
+    t.index ["task_id"], name: "index_test_attempts_on_task_id"
   end
 
   create_table "tii_actions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -464,6 +471,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.integer "capacity", default: -1
     t.bigint "campus_id"
     t.bigint "tutorial_stream_id"
+    t.index ["abbreviation", "unit_id"], name: "index_tutorials_on_abbreviation_and_unit_id", unique: true
     t.index ["campus_id"], name: "index_tutorials_on_campus_id"
     t.index ["tutorial_stream_id"], name: "index_tutorials_on_tutorial_stream_id"
     t.index ["unit_id"], name: "index_tutorials_on_unit_id"
@@ -507,10 +515,30 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.bigint "overseer_image_id"
     t.datetime "portfolio_auto_generation_date"
     t.string "tii_group_context_id"
+    t.boolean "archived", default: false
     t.index ["draft_task_definition_id"], name: "index_units_on_draft_task_definition_id"
     t.index ["main_convenor_id"], name: "index_units_on_main_convenor_id"
     t.index ["overseer_image_id"], name: "index_units_on_overseer_image_id"
     t.index ["teaching_period_id"], name: "index_units_on_teaching_period_id"
+  end
+
+  create_table "user_oauth_states", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["state"], name: "index_user_oauth_states_on_state", unique: true
+    t.index ["user_id"], name: "index_user_oauth_states_on_user_id"
+  end
+
+  create_table "user_oauth_tokens", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "provider", default: 0, null: false
+    t.text "token"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_oauth_tokens_on_user_id"
   end
 
   create_table "users", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -542,8 +570,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.string "tii_eula_version"
     t.datetime "tii_eula_date"
     t.boolean "tii_eula_version_confirmed", default: false, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["login_id"], name: "index_users_on_login_id", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
+    t.index ["student_id"], name: "index_users_on_student_id", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   create_table "webcal_unit_exclusions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -564,11 +595,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_12_012227) do
     t.index ["user_id"], name: "index_webcals_on_user_id", unique: true
   end
 
-  add_foreign_key "marking_sessions", "units"
-  add_foreign_key "marking_sessions", "users", column: "marker_id"
-  add_foreign_key "session_activities", "marking_sessions"
-  add_foreign_key "session_activities", "projects"
-  add_foreign_key "session_activities", "task_definitions"
-  add_foreign_key "session_activities", "tasks"
   add_foreign_key "task_definitions", "tutorial_streams", column: "tutorial_self_enrolment_stream_id"
+  add_foreign_key "user_oauth_states", "users"
+  add_foreign_key "user_oauth_tokens", "users"
 end

--- a/test/models/task_definition_test.rb
+++ b/test/models/task_definition_test.rb
@@ -269,4 +269,39 @@ class TaskDefinitionTest < ActiveSupport::TestCase
     unit.destroy
   end
 
+  def test_tutorial_self_enrolment_valid_and_invalid
+    unit = FactoryBot.create(:unit)
+    activity = FactoryBot.create(:activity_type)
+    stream1 = FactoryBot.create(:tutorial_stream, unit: unit, activity_type: activity)
+    stream2 = FactoryBot.create(:tutorial_stream, unit: unit, activity_type: activity)
+
+    #valid case: self-enrolment stream in same unit
+    td_valid = FactoryBot.build(:task_definition,
+      unit: unit,
+      tutorial_stream: stream1,
+      tutorial_self_enrolment_enabled: true,
+      tutorial_self_enrolment_stream: stream2
+    )
+
+    assert td_valid.valid?, "TaskDefinition should be valid when self enrolment stream is in the same unit"
+    td_valid.save!
+
+    assert td_valid.tutorial_self_enrolment_enabled?
+    assert_equal stream2, td_valid.tutorial_self_enrolment_stream
+
+    # invalid case: self-enrolment stream from another unit
+    other_unit = FactoryBot.create(:unit)
+    other_stream = FactoryBot.create(:tutorial_stream, unit: other_unit, activity_type: activity)
+
+    td_invalid = FactoryBot.build(:task_definition,
+      unit: unit,
+      tutorial_stream: stream1,
+      tutorial_self_enrolment_enabled: true,
+      tutorial_self_enrolment_stream: other_stream
+    )
+
+    refute td_invalid.valid?, "TaskDefinition should not be valid with self enrolment stream from another unit"
+    assert_includes td_invalid.errors[:tutorial_self_enrolment_stream], "must belong to the same unit"
+  end
+
 end


### PR DESCRIPTION
# Description

For this task I updated the **TaskDefinition** and **TutorialStream** models to add support for tutorial self-enrolment.  
The change adds two new fields on the `task_definitions` table:

- `tutorial_self_enrolment_enabled` → a boolean flag that turns the feature on/off  
- `tutorial_self_enrolment_stream_id` → a foreign key pointing to a tutorial stream that students can self-enrol into  

I also added the associations between models, validation to make sure the enrolment stream belongs to the same unit, and a reverse association on the **TutorialStream** side.


## Type of change
This is part of a new feature for the student self enrollment. 
- [ x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

### Manual Testing in Rails Console
- Created a valid `TaskDefinition` with self-enrolment enabled → it saved successfully, associations linked up correctly.  
- Tried creating one pointing to a stream from a different unit → failed as expected with the correct error.  

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation if appropriate
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have created or extended unit tests to address my new additions
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.


### Automated Test (`test/models/task_definition_test.rb`)
```ruby
def test_tutorial_self_enrolment_valid_and_invalid
  unit = FactoryBot.create(:unit)
  activity = FactoryBot.create(:activity_type)
  stream1 = FactoryBot.create(:tutorial_stream, unit: unit, activity_type: activity)
  stream2 = FactoryBot.create(:tutorial_stream, unit: unit, activity_type: activity)

  # valid case, should save
  td_valid = TaskDefinition.new(
    unit: unit,
    tutorial_stream: stream1,
    tutorial_self_enrolment_enabled: true,
    tutorial_self_enrolment_stream: stream2,
    name: "ok task",
    abbreviation: "VAL1",
    weighting: 10,
    target_grade: 0,
    start_date: unit.start_date || Time.zone.today,
    target_date: Time.zone.today + 1.week
  )
  assert td_valid.valid?, "should be valid when stream is in the same unit"

  # invalid case (wrong unit)
  other_unit = FactoryBot.create(:unit)
  other_stream = FactoryBot.create(:tutorial_stream, unit: other_unit, activity_type: activity)
  td_invalid = td_valid.dup
  td_invalid.abbreviation = "INV1"
  td_invalid.tutorial_self_enrolment_stream = other_stream

  assert_not td_invalid.valid?, "should fail when stream from another unit"
  assert_includes td_invalid.errors[:tutorial_self_enrolment_stream], "must belong to the same unit"
end