### PR TITLE
Student self enrolment api entity update

### DIFF
--- a/app/api/entities/task_definition_entity.rb
+++ b/app/api/entities/task_definition_entity.rb
@@ -44,5 +44,10 @@ module Entities
     expose :overseer_image_id, if: ->(unit, options) { staff?(options[:my_role]) }
     expose :assessment_enabled, if: ->(unit, options) { staff?(options[:my_role]) }
     expose :moss_language, if: ->(unit, options) { staff?(options[:my_role]) }
+    expose :tutorial_self_enrolment_enabled
+    expose :tutorial_self_enrolment_stream_id
+    expose :tutorial_self_enrolment_stream_abbr, expose_nil: true do |task_definition, _options|
+      task_definition.tutorial_self_enrolment_stream&.abbreviation
+    end
   end
 end

--- a/test/api/tasks_api_test.rb
+++ b/test/api/tasks_api_test.rb
@@ -406,5 +406,39 @@ class TasksApiTest < ActiveSupport::TestCase
     td.destroy
   end
 
+  def test_exposes_tutorial_self_enrolment_fields
+    unit = FactoryBot.create(:unit)
+    activity = FactoryBot.create(:activity_type)
+    stream = FactoryBot.create(:tutorial_stream, unit: unit, activity_type: activity)
 
+    # Task with self enrolment enabled
+    td_enabled = FactoryBot.create(
+      :task_definition,
+      unit: unit,
+      tutorial_stream: stream,
+      tutorial_self_enrolment_enabled: true,
+      tutorial_self_enrolment_stream: stream
+    )
+
+    json = Entities::TaskDefinitionEntity.represent(td_enabled, my_role: nil).as_json
+
+    assert_equal true, json[:tutorial_self_enrolment_enabled], "expected enrolment flag to be true"
+    assert_equal stream.id, json[:tutorial_self_enrolment_stream_id], "expected stream id to match"
+    assert_equal stream.abbreviation, json[:tutorial_self_enrolment_stream_abbr], "expected abbr to match"
+
+    # Task with self enrolment disabled
+    td_disabled = FactoryBot.create(
+      :task_definition,
+      unit: unit,
+      tutorial_stream: stream,
+      tutorial_self_enrolment_enabled: false,
+      tutorial_self_enrolment_stream: nil
+    )
+
+    json = Entities::TaskDefinitionEntity.represent(td_disabled, my_role: nil).as_json
+
+    assert_equal false, json[:tutorial_self_enrolment_enabled], "expected enrolment flag to be false"
+    assert_nil json[:tutorial_self_enrolment_stream_id], "expected no stream id"
+    assert_nil json[:tutorial_self_enrolment_stream_abbr], "expected no stream abbr"
+  end
 end


### PR DESCRIPTION
# Description

This update adds support for **tutorial self-enrolment** in the backend.  

- Added two new fields on `task_definitions`:  
  - `tutorial_self_enrolment_enabled` (boolean flag)  
  - `tutorial_self_enrolment_stream_id` (FK → `tutorial_streams`)  
- Updated `TaskDefinitionEntity` to expose these fields in the API.  

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

### Manual testing (Rails console)  
- Created a task with self-enrolment enabled and linked it to a valid tutorial stream → saved successfully, fields appeared in the API JSON.  
- Tried linking a task to a tutorial stream from a different unit → validation failed with the correct error.  

### Automated tests  
- **Model test** (`test/models/task_definition_test.rb`):  
  - Valid case → task saved correctly with a stream in the same unit.  
  - Invalid case → task rejected when using a stream from another unit.  

- **Entity test** (`test/api/task_api_test.rb`):  
  - When enabled → API JSON shows `tutorial_self_enrolment_enabled: true`, plus correct stream id and abbreviation.  
  - When disabled → API JSON shows `tutorial_self_enrolment_enabled: false` and stream fields as `nil`.  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
